### PR TITLE
Optimize search and memory usage for AVR

### DIFF
--- a/thermocouple.c
+++ b/thermocouple.c
@@ -1,143 +1,11 @@
-#include <stdio.h>
-
-#define POINTS_COUNT 65
-
-typedef	struct {
-	long temp;
-	unsigned long microvolts;
-} temp_point;
-
-static temp_point thermocouplePoints[] = {
-{ 0 , 0 },
-{ 10000 , 397 },
-{ 20000 , 798 },
-{ 30000 , 1203 },
-{ 40000 , 1612 },
-{ 50000 , 2023 },
-{ 60000 , 2436 },
-{ 79000 , 3225 },
-{ 98000 , 4013 },
-{ 116000 , 4756 },
-{ 134000 , 5491 },
-{ 139000 , 5694 },
-{ 155000 , 6339 },
-{ 172000 , 7021 },
-{ 193000 , 7859 },
-{ 212000 , 8619 },
-{ 231000 , 9383 },
-{ 250000 , 10153 },
-{ 269000 , 10930 },
-{ 288000 , 11712 },
-{ 307000 , 12499 },
-{ 326000 , 13290 },
-{ 345000 , 14084 },
-{ 364000 , 14881 },
-{ 383000 , 15680 },
-{ 402000 , 16482 },
-{ 421000 , 17285 },
-{ 440000 , 18091 },
-{ 459000 , 18898 },
-{ 478000 , 19707 },
-{ 497000 , 20516 },
-{ 516000 , 21326 },
-{ 535000 , 22137 },
-{ 554000 , 22947 },
-{ 573000 , 23757 },
-{ 592000 , 24565 },
-{ 611000 , 25373 },
-{ 630000 , 26179 },
-{ 649000 , 26983 },
-{ 668000 , 27784 },
-{ 687000 , 28584 },
-{ 706000 , 29380 },
-{ 725000 , 30174 },
-{ 744000 , 30964 },
-{ 763000 , 31752 },
-{ 782000 , 32536 },
-{ 801000 , 33316 },
-{ 820000 , 34093 },
-{ 839000 , 34867 },
-{ 858000 , 35637 },
-{ 877000 , 36403 },
-{ 896000 , 37166 },
-{ 915000 , 37925 },
-{ 934000 , 38680 },
-{ 953000 , 39432 },
-{ 972000 , 40180 },
-{ 991000 , 40924 },
-{ 1010000 , 41665 },
-{ 1029000 , 42402 },
-{ 1048000 , 43134 },
-{ 1067000 , 43863 },
-{ 1086000 , 44588 },
-{ 1105000 , 45308 },
-{ 1124000 , 46024 },
-{ 1143000 , 46735 },
-{ 1200000 , 48838 }
-};
-
-static inline unsigned long interpolate(unsigned long val, unsigned long rangeStart, unsigned long rangeEnd, unsigned long valStart, unsigned long valEnd) {
-    return rangeStart + (rangeEnd - rangeStart) * (val - valStart) / (valEnd - valStart);
-}
-
-static inline unsigned long interpolateVoltage(unsigned long temp, unsigned char i){
-    return interpolate(temp, thermocouplePoints[i-1].microvolts, thermocouplePoints[i].microvolts, thermocouplePoints[i-1].temp, thermocouplePoints[i].temp);
-}
-
-static inline unsigned long interpolateTemperature(unsigned long microvolts, unsigned char i){
-    return interpolate(microvolts, thermocouplePoints[i-1].temp, thermocouplePoints[i].temp, thermocouplePoints[i-1].microvolts, thermocouplePoints[i].microvolts);
-}
-
-/**
- * Returns the index of the first point whose temperature value is greater than argument
- **/
-static inline unsigned char searchTemp(unsigned long temp) {
-	unsigned char i;
-	for(i = 0; i < POINTS_COUNT; i++) {
-		if(thermocouplePoints[i].temp > temp) {
-			return i;
-		}
-	}
-	return POINTS_COUNT-1;
-}
-
-/**
- * Returns the index of the first point whose microvolts value is greater than argument
- **/
-static inline unsigned char searchMicrovolts(unsigned long microvolts) {
-	unsigned char i;
-	for(i = 0; i < POINTS_COUNT; i++) {
-		if(thermocouplePoints[i].microvolts > microvolts) {
-			return i;
-		}
-	}
-	return POINTS_COUNT-1;
-}
-
-/**
- * Returns temperature as a function of the ambient temperature and measured thermocouple voltage.
- * Currently only positive ambient temperature is supported
- **/
-long thermocoupleConvertWithCJCompensation(unsigned long microvoltsMeasured, unsigned long ambient) {
-	//convert ambient temp to microvolts
-	//and add them to the thermocouple measured microvolts 
-	unsigned long microvolts = microvoltsMeasured + interpolateVoltage(ambient, searchTemp(ambient));
-	//look up microvolts in The Table and interpolate
-	return interpolateTemperature(microvolts, searchMicrovolts(microvolts));
-}
-
-/**
- * Returns temperature, equivalent to the voltage provided in microvolts
- */
-long thermocoupleMvToC(unsigned long microvolts) {
-	return interpolateTemperature(microvolts, searchMicrovolts(microvolts));
-}
-
 /******************************************************************************
  * Additional info
  * ****************************************************************************
  * Changelog:
- * - v. 1.0 (initial release) 2014-04-24 by Albertas Mickėnas mic@wemakethings.net
+ * - v. 2.0 Optimize memory usage. Option to use binary search.
+ *   2016-01-09 by Joakim Soderberg joakim.soderberg@gmail.com
+ * - v. 1.0 Initial release)
+ *   2014-04-24 by Albertas Mickėnas mic@wemakethings.net
  *
  * ****************************************************************************
  * Bugs, feedback, questions and modifications can be posted on the github page
@@ -151,14 +19,365 @@ long thermocoupleMvToC(unsigned long microvolts) {
  * ****************************************************************************
  */
 
-//~ void main(int argc, char **argv) {
-	//~ unsigned long i = 0;
-	//~ for(i = 0; i < 16383; i++) {
-		//~ unsigned long voltage = 5000000 / 16384 * i / 101;
-		//~ printf("%ld\n", thermocoupleMvToC(voltage));
-	//~ }
-	//~ for(i = 0; i < 1280000; i+=1000) {
-		//~ printf("%ld\n", interpolateVoltage(i, searchTemp(i)));
-	//~ }
-//~ }
+#include <stdio.h>
+#include "thermocouple.h"
 
+#ifdef __AVR__
+#include <avr/pgmspace.h>
+#else
+#undef KTHERM_WITH_PROGMEM
+#endif
+
+#ifdef KTHERM_TEST
+#include <string.h>
+#endif
+
+/*
+ * Values for this table should be multiplied with 1000 when used.
+ * If we store the table as that instead, we need to use unsigned long
+ * For example it would need (on an ATmega328):
+ *    66 * 4 = 264 bytes
+ * instead of:
+ *    66 * 2 = 132 bytes
+ */
+#define TEMP_TABLE_SCALE 1000
+static const unsigned int temp_table[]
+    #ifdef KTHERM_WITH_PROGMEM
+    PROGMEM
+    #endif
+    = {
+    0,
+    10,
+    20,
+    30,
+    40,
+    50,
+    60,
+    79,
+    98,
+    116,
+    134,
+    139,
+    155,
+    172,
+    193,
+    212,
+    231,
+    250,
+    269,
+    288,
+    307,
+    326,
+    345,
+    364,
+    383,
+    402,
+    421,
+    440,
+    459,
+    478,
+    497,
+    516,
+    535,
+    554,
+    573,
+    592,
+    611,
+    630,
+    649,
+    668,
+    687,
+    706,
+    725,
+    744,
+    763,
+    782,
+    801,
+    820,
+    839,
+    858,
+    877,
+    896,
+    915,
+    934,
+    953,
+    972,
+    991,
+    1010,
+    1029,
+    1048,
+    1067,
+    1086,
+    1105,
+    1124,
+    1143,
+    1200
+};
+
+#define TEMP_TABLE_SIZE (sizeof(temp_table) / sizeof(temp_table[0]))
+
+static const unsigned int volt_table[]
+    #ifdef KTHERM_WITH_PROGMEM
+    PROGMEM
+    #endif
+    = {
+    0,
+    397,
+    798,
+    1203,
+    1612,
+    2023,
+    2436,
+    3225,
+    4013,
+    4756,
+    5491,
+    5694,
+    6339,
+    7021,
+    7859,
+    8619,
+    9383,
+    10153,
+    10930,
+    11712,
+    12499,
+    13290,
+    14084,
+    14881,
+    15680,
+    16482,
+    17285,
+    18091,
+    18898,
+    19707,
+    20516,
+    21326,
+    22137,
+    22947,
+    23757,
+    24565,
+    25373,
+    26179,
+    26983,
+    27784,
+    28584,
+    29380,
+    30174,
+    30964,
+    31752,
+    32536,
+    33316,
+    34093,
+    34867,
+    35637,
+    36403,
+    37166,
+    37925,
+    38680,
+    39432,
+    40180,
+    40924,
+    41665,
+    42402,
+    43134,
+    43863,
+    44588,
+    45308,
+    46024,
+    46735,
+    48838
+};
+
+#define VOLTAGE_TABLE_SIZE (sizeof(volt_table) / sizeof(volt_table[0]))
+#define POINTS_COUNT (VOLTAGE_TABLE_SIZE - 1)
+
+static inline unsigned long getTableVal(const unsigned int *t,
+                                        unsigned char i)
+{
+    #ifdef KTHERM_WITH_PROGMEM
+    return (unsigned long)pgm_read_word_near(t + i);
+    #else
+    return (unsigned long)t[i];
+    #endif
+}
+
+static inline unsigned long interpolate(unsigned long val,
+                                        unsigned long rangeStart,
+                                        unsigned long rangeEnd,
+                                        unsigned long valStart,
+                                        unsigned long valEnd)
+{
+    unsigned long valDiff = valEnd - valStart;
+
+    if (valDiff == 0)
+        return 0;
+
+    return rangeStart + (rangeEnd - rangeStart) * (val - valStart) / valDiff;
+}
+
+static inline unsigned long interpolateVoltage(unsigned long temp,
+                                               unsigned char i)
+{
+    return interpolate(temp,
+                       getTableVal(volt_table, i - 1),
+                       getTableVal(volt_table, i),
+                       getTableVal(temp_table, i - 1) * TEMP_TABLE_SCALE,
+                       getTableVal(temp_table, i) * TEMP_TABLE_SCALE);
+}
+
+static inline unsigned long interpolateTemperature(unsigned long microvolts,
+                                                   unsigned char i)
+{
+    return interpolate(microvolts,
+                       getTableVal(temp_table, i - 1) * TEMP_TABLE_SCALE,
+                       getTableVal(temp_table, i) * TEMP_TABLE_SCALE,
+                       getTableVal(volt_table, i - 1),
+                       getTableVal(volt_table, i));
+}
+
+static inline unsigned char binarySearch(const unsigned int *t,
+                                         unsigned long val,
+                                         unsigned long scale)
+{
+    unsigned char first;
+    unsigned char middle;
+    unsigned char last;
+    unsigned long cur;
+
+    // Note that we skip the first item in the list.
+    first = 1;
+    last = POINTS_COUNT - 2;
+    middle = (first + last) / 2;
+
+    while (first <= last)
+    {
+        cur = getTableVal(t, middle) * scale;
+
+        if (val > cur)
+        {
+            first = middle + 1;
+        }
+        else if (val == cur)
+        {
+            return middle + 1;
+        }
+        else
+        {
+            last = middle - 1;
+        }
+
+        middle = (first + last) / 2;
+    }
+
+    return last + 1;
+}
+
+static inline unsigned char linearSearch(const unsigned int *t,
+                                         unsigned long val,
+                                         unsigned long scale)
+{
+    unsigned char i;
+
+    for (i = 0; i < POINTS_COUNT; i++)
+    {
+        if ((getTableVal(t, i) * scale) > val)
+        {
+            return i;
+        }
+    }
+    return POINTS_COUNT - 1;
+}
+
+/**
+ * Returns the index of the first point whose temperature
+ * value is greater than argument
+ **/
+static inline unsigned char searchTemp(unsigned long temp)
+{
+    #ifdef KTHERM_WITH_BINARY_SEARCH
+    return binarySearch(temp_table, temp, TEMP_TABLE_SCALE);
+    #else
+    return linearSearch(temp_table, temp, TEMP_TABLE_SCALE);
+    #endif
+}
+
+/**
+ * Returns the index of the first point whose microvolts
+ * value is greater than argument
+ **/
+static inline unsigned char searchMicrovolts(unsigned long microvolts)
+{
+    #ifdef KTHERM_WITH_BINARY_SEARCH
+    return binarySearch(volt_table, microvolts, 1);
+    #else
+    return linearSearch(volt_table, microvolts, 1);
+    #endif
+}
+
+/**
+ * Returns temperature as a function of the ambient temperature
+ * and measured thermocouple voltage.
+ * Currently only positive ambient temperature is supported
+ **/
+long thermocoupleConvertWithCJCompensation(unsigned long microvoltsMeasured,
+                                           unsigned long ambient)
+{
+    // Convert ambient temp to microvolts
+    // and add them to the thermocouple measured microvolts 
+    unsigned long microvolts = 
+        microvoltsMeasured + interpolateVoltage(ambient, searchTemp(ambient));
+
+    // look up microvolts in The Table and interpolate
+    return interpolateTemperature(microvolts, searchMicrovolts(microvolts));
+}
+
+/**
+ * Returns temperature, equivalent to the voltage provided in microvolts
+ */
+long thermocoupleMvToC(unsigned long microvolts)
+{
+    return interpolateTemperature(microvolts, searchMicrovolts(microvolts));
+}
+
+#ifdef KTHERM_TEST
+int main(int argc, char **argv)
+{
+    unsigned long i = 0;
+
+    if (argc < 2)
+    {
+        goto usage;
+    }
+
+    for (i = 1; i < argc; i++)
+    {
+        if (!strcmp(argv[i], "--temps"))
+        {
+            for (i = 0; i < 16383; i++)
+            {
+                unsigned long voltage = 5000000 / 16384 * i / 101;
+                printf("%ld\n", thermocoupleMvToC(voltage));
+            }
+        }
+        else if (!strcmp(argv[i], "--microvolts"))
+        {
+            for (i = 0; i < 1280000; i+= 1000)
+            {
+                printf("%ld\n", interpolateVoltage(i, searchTemp(i)));
+            }
+        }
+        else
+        {
+            fprintf(stderr, "Unknown option %s\n", argv[i]);
+            goto usage;
+        }
+    }
+
+    return 0;
+usage:
+    printf("K-Type Thermocouple Library Tests\n");
+    printf(" Usage: %s [--microvolts] [--temps]\n", argv[0]);
+    return -1;
+}
+#endif

--- a/thermocouple.h
+++ b/thermocouple.h
@@ -1,3 +1,23 @@
+/******************************************************************************
+ * Additional info
+ * ****************************************************************************
+ * Changelog:
+ * - v. 2.0 Optimize memory usage. Option to use binary search.
+ *   2016-01-09 by Joakim Soderberg joakim.soderberg@gmail.com
+ * - v. 1.0 Initial release)
+ *   2014-04-24 by Albertas Mickėnas mic@wemakethings.net
+ *
+ * ****************************************************************************
+ * Bugs, feedback, questions and modifications can be posted on the github page
+ * on https://github.com/Miceuz/k-thermocouple-lib/
+ * ****************************************************************************
+ * - LICENSE -
+ * GNU GPL v2 (http://www.gnu.org/licenses/gpl.txt)
+ * This program is free software. You can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as published
+ * by the Free Software Foundation.
+ * ****************************************************************************
+ */
 #ifndef __THERMOCOUPLE_H
 #define __THERMOCOUPLE_H
 
@@ -20,21 +40,3 @@ long thermocoupleMvToC(unsigned long microvolts);
 #endif
 #endif // _THERMOCOUPLE_H
 
-
-/******************************************************************************
- * Additional info
- * ****************************************************************************
- * Changelog:
- * - v. 1.0 (initial release) 2014-04-24 by Albertas Mickėnas mic@wemakethings.net
- *
- * ****************************************************************************
- * Bugs, feedback, questions and modifications can be posted on the github page
- * on https://github.com/Miceuz/k-thermocouple-lib/
- * ****************************************************************************
- * - LICENSE -
- * GNU GPL v2 (http://www.gnu.org/licenses/gpl.txt)
- * This program is free software. You can redistribute it and/or modify
- * it under the terms of the GNU General Public License version 2 as published
- * by the Free Software Foundation.
- * ****************************************************************************
- */


### PR DESCRIPTION
- Separate table into two (to enable using generic algorithms on both).
- On AVR support saving the tables into flash instead of RAM. 520 bytes of ram usage in old version.
- Made the tables "unsigned int" instead of "unsigned long" since it was not needed. Instead we scale the temperatures at use.
- Added a binary search instead of linear search over the value giving O(log(n)) instead of O(n).
- Added defines to turn on all of these new things conditionally when compiling (Default is to work as previous version with linear search).
- Made a nicer test harness to make it easier to validate against the test_\* files
